### PR TITLE
Fix papaya mime server tests

### DIFF
--- a/flsim/clients/sync_mime_client.py
+++ b/flsim/clients/sync_mime_client.py
@@ -9,6 +9,7 @@ Should be used in conjunction with the synchronous MIME server.
 Needs the server_opt_state and server_control_variate to function
 """
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -82,8 +83,8 @@ class MimeClient(Client):
         return delta, weight
 
     def _reload_server_state(self, optimizer):
-        state_dict = optimizer.state_dict()
-        state_dict["state"] = self.server_opt_state
+        state_dict = deepcopy(optimizer.state_dict())
+        state_dict["state"] = deepcopy(self.server_opt_state)
         optimizer.load_state_dict(state_dict)
         del state_dict
 

--- a/flsim/clients/sync_mimelite_client.py
+++ b/flsim/clients/sync_mimelite_client.py
@@ -9,6 +9,7 @@ Should be used in conjunction with the synchronous MIMELite server.
 Needs the server_opt_state to function
 """
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -51,8 +52,8 @@ class MimeLiteClient(Client):
         return delta, weight
 
     def _reload_server_state(self, optimizer):
-        state_dict = optimizer.state_dict()
-        state_dict["state"] = self.server_opt_state
+        state_dict = deepcopy(optimizer.state_dict())
+        state_dict["state"] = deepcopy(self.server_opt_state)
         optimizer.load_state_dict(state_dict)
         del state_dict
 

--- a/flsim/servers/sync_mime_servers.py
+++ b/flsim/servers/sync_mime_servers.py
@@ -107,7 +107,7 @@ class SyncMimeServer(SyncServer):
 
         return Message(
             model=self.global_model,
-            server_opt_state=self._state_optimizer.state_dict()["state"],
+            server_opt_state=copy.deepcopy(self._state_optimizer.state_dict()["state"]),
             mime_control_variate=self._grad_average,
         )
 

--- a/flsim/servers/sync_mimelite_servers.py
+++ b/flsim/servers/sync_mimelite_servers.py
@@ -108,7 +108,7 @@ class SyncMimeLiteServer(SyncServer):
 
         return Message(
             model=self.global_model,
-            server_opt_state=self._state_optimizer.state_dict()["state"],
+            server_opt_state=copy.deepcopy(self._state_optimizer.state_dict()["state"]),
         )
 
     def step(self):


### PR DESCRIPTION
Summary: Fixes broken tests due to optimizer state_dict being a shallow copy when handled in load_state_dict.

Differential Revision: D48019676

